### PR TITLE
Add PR previews

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,8 @@ jobs:
         run: npm run build
       - name: Deploy
         if: github.ref == 'refs/heads/main'
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          BRANCH: gh-pages
-          FOLDER: dist
+          branch: gh-pages
+          folder: dist
+          clean-exclude: pr-preview/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: build
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,7 +13,6 @@ jobs:
       - name: Build
         run: npm run build
       - name: Deploy
-        if: github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,29 @@
+name: preview PR
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+    paths:
+      - css/**
+      - html/**
+      - js/**
+      - build.js
+      - .github/workflows/preview.yml
+concurrency: preview-${{ github.ref }}
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install
+        run: npm install
+      - name: Build
+        run: npm run build
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: dist


### PR DESCRIPTION
[I made an Action](https://github.com/rossjrw/pr-preview-action) for generating previews of pull requests. I've been having trouble with testing #8 (localhost doesn't want to talk to Crom/Wikidot for some reason, even when running a server), and don't much fancy uploading files to Wikidot every time I change something. So I'm hoping that deploying tests to Pages and pulling from there will be easier - plus, it has the following advantages:

- everyone on the tech team can instantly see changes
- if it doesn't work, then we'll know that our plan to host the interwiki off the .github.io won't work either
- just neat to have, imo