### PR TITLE
Have index.html redirect to repository

### DIFF
--- a/build.js
+++ b/build.js
@@ -14,6 +14,6 @@ esbuild.buildSync({
   target: "es5",
 });
 
-["interwikiFrame", "styleFrame"].forEach(function (frame) {
+["interwikiFrame", "styleFrame", "index"].forEach(function (frame) {
   fs.copyFileSync("html/" + frame + ".html", "dist/" + frame + ".html");
 });

--- a/html/index.html
+++ b/html/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta
+      http-equiv="Refresh"
+      content="0; url='https://github.com/scpwiki/interwiki'"
+    />
+  </head>
+</html>


### PR DESCRIPTION
Adds an index html that will redirect any curious snoopers navigating directly to `interwiki.scpwiki.com` to this repository.