### PR TITLE
Resize via observer

### DIFF
--- a/js/createResizeIframe.js
+++ b/js/createResizeIframe.js
@@ -2,7 +2,7 @@
  * Whether the interwiki should be visible. It should only be visible after
  * data has been received from the API source.
  */
-var showInterwiki = false;
+export var flags = { showInterwiki: false };
 
 /**
  * Constructs and returns a function that, when called, resizes the current
@@ -21,8 +21,8 @@ export function createResizeIframe(site, frameId) {
   if (frameId[0] !== "/") frameId = "/" + frameId;
 
   return debounce(function (receivedData) {
-    if (receivedData) showInterwiki = true;
-    if (showInterwiki) {
+    if (receivedData) flags.showInterwiki = true;
+    if (flags.showInterwiki) {
       // Measure from the top of the document to the iframe container to get
       // the document height - this takes into account inner margins, unlike
       // e.g. document.body.clientHeight

--- a/js/interwiki.js
+++ b/js/interwiki.js
@@ -107,10 +107,7 @@ export function createInterwiki(
 
   // Construct the function that will be called internally and by
   // styleFrames to request style changes
-  window.requestStyleChange = createRequestStyleChange(
-    currentBranch.url || "",
-    resize
-  );
+  window.requestStyleChange = createRequestStyleChange(currentBranch.url || "");
 
   // Add Wikidot's base style unless instructed otherwise
   if (preventWikidotBaseStyle !== "true") {

--- a/js/interwiki.js
+++ b/js/interwiki.js
@@ -121,5 +121,5 @@ export function createInterwiki(
   }
 
   pullStyles();
-  addTranslations(branches, currentBranchLang, pagename, resize);
+  addTranslations(branches, currentBranchLang, pagename);
 }

--- a/js/interwiki.js
+++ b/js/interwiki.js
@@ -5,6 +5,8 @@ import { addExternalStyle, createRequestStyleChange } from "./styles";
 import { scpBranches } from "./branches-info-scp";
 import { wlBranches } from "./branches-info-wl";
 
+import { ResizeObserver } from "@juggle/resize-observer";
+
 addEventListener("DOMContentLoaded", function () {
   var community = getQueryString(location.search, "community");
   var pagename = getQueryString(location.search, "pagename");
@@ -104,6 +106,10 @@ export function createInterwiki(
   var site = document.referrer;
   var frameId = location.href.replace(/^.*\//, "/");
   var resize = createResizeIframe(site, frameId);
+
+  // Resize frame when size changes are detected
+  var observer = new ResizeObserver(resize);
+  observer.observe(document.documentElement);
 
   // Construct the function that will be called internally and by
   // styleFrames to request style changes

--- a/js/links.js
+++ b/js/links.js
@@ -1,3 +1,4 @@
+import { flags } from "./createResizeIframe";
 import { cromLookup } from "./lookup/crom";
 
 // Configure which lookup method is currently active
@@ -43,10 +44,8 @@ var lookupMethod = cromLookup;
  * branch, as defined in the community's branches config.
  * @param {String} pagename - The fullname of the page in the current
  * branch to find translations for.
- * @param {Function} resize - A callback to resize the iframe after adding
- * a new translation.
  */
-export function addTranslations(branches, currentBranchLang, pagename, resize) {
+export function addTranslations(branches, currentBranchLang, pagename) {
   // Get the config for the current branch, if configured
   var currentBranch = branches[currentBranchLang] || {};
 
@@ -65,9 +64,8 @@ export function addTranslations(branches, currentBranchLang, pagename, resize) {
     pagename,
     function (pageUrl, branchName, branchLang, isOriginal) {
       addTranslationLink(pageUrl, branchName, branchLang, isOriginal);
-      // Resize the iframe to account for the new link and indicate that
-      // data has been received
-      resize(true);
+      // Indicate that data has been received
+      flags.showInterwiki = true;
     }
   );
 }

--- a/js/styles.js
+++ b/js/styles.js
@@ -9,7 +9,7 @@ import { getQueryString } from "./interwiki";
  * @param {Function} resize - A function to call to resize the interwiki
  * iframe after adding new CSS.
  */
-export function createRequestStyleChange(siteUrl, resize) {
+export function createRequestStyleChange(siteUrl) {
   /**
    * Handles a style request from a styleFrame.
    *
@@ -25,10 +25,10 @@ export function createRequestStyleChange(siteUrl, resize) {
     }
 
     var theme = getQueryString(request, "theme");
-    if (theme) addExternalStyle(priority, urlFromTheme(siteUrl, theme), resize);
+    if (theme) addExternalStyle(priority, urlFromTheme(siteUrl, theme));
 
     var css = getQueryString(request, "css");
-    if (css) addInternalStyle(priority, css, resize);
+    if (css) addInternalStyle(priority, css);
   };
 }
 
@@ -38,10 +38,8 @@ export function createRequestStyleChange(siteUrl, resize) {
  * @param {Number} priority - The priority of the CSS, which determines the
  * sort order.
  * @param {String} css - Raw CSS to add to the style.
- * @param {Function} resize - Callback to resize the iframe after applying
- * the style.
  */
-function addInternalStyle(priority, css, resize) {
+function addInternalStyle(priority, css) {
   // Check that the incoming CSS doesn't duplicate an existing style
   var styleElements = Array.prototype.slice.call(
     document.head.querySelectorAll("style.custom-style")
@@ -54,10 +52,6 @@ function addInternalStyle(priority, css, resize) {
 
   // Insert the style into the appropriate position in the head
   insertStyle(priority, style);
-
-  // There is no reliable way to detect when the style has been applied to
-  // the document, so wait a tick before resizing the iframe
-  setTimeout(resize, 250);
 }
 
 /**
@@ -67,10 +61,8 @@ function addInternalStyle(priority, css, resize) {
  * @param {Number} priority - The priority of the CSS, which determines the
  * sort order.
  * @param {String} url - The URL of the CSS stylesheet.
- * @param {Function} resize - Callback to resize the iframe after applying
- * the style.
  */
-export function addExternalStyle(priority, url, resize) {
+export function addExternalStyle(priority, url) {
   // Check that the incoming link doesn't duplicate an existing style
   var linkElements = Array.prototype.slice.call(
     document.head.querySelectorAll("link.custom-style")
@@ -80,11 +72,6 @@ export function addExternalStyle(priority, url, resize) {
   // Create a new link element for the stylesheet
   var link = document.createElement("link");
   link.rel = "stylesheet";
-
-  // There is no way to detect when the style from the stylesheet has been
-  // applied to the document - best that can be done is to wait a tick
-  // after the stylesheet has been retrieved
-  link.addEventListener("load", resize);
   link.href = url;
 
   // Insert the link into the appropriate position in the head

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "node build.js"
   },
   "devDependencies": {
+    "@juggle/resize-observer": "^3.3.1",
     "esbuild": "^0.14.23",
     "eslint": "^7.32.0",
     "eslint-plugin-es": "^4.1.0",


### PR DESCRIPTION
Merges into #8.

Currently a resize function is called after the following events:

* Immediately after using API data to add translation links
* Shortly after inserting given CSS into a `<style>` element
* Shortly after the `load` event of acquiring an external CSS stylesheet via a `link` element

This works well - but not perfectly. In some edge cases, there's still a bit of vertical scroll after everything has settled.

What I'd really like to do is use ResizeObserver to call the resize function whenever it deems necessary, and then remove the `resize` callback that deeply penetrates the interwiki procedure. This should simplify the codebase while making resizing more reliable.