### PR TITLE
Fix vertical height when initially hidden

### DIFF
--- a/html/interwikiFrame.html
+++ b/html/interwikiFrame.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="interwiki">
+<html id="interwiki" style="min-width: max-content">
 
 <head>
   <meta name="viewport" content="width=device-width,initial-scale=1" />


### PR DESCRIPTION
Fixes #13 by adding an initial width to the frame, preventing line overflow from extending the document's height.