### PR TITLE
Make requests to Crom API over GET

### DIFF
--- a/js/lookup/crom.js
+++ b/js/lookup/crom.js
@@ -137,8 +137,13 @@ function parseTranslations(response, currentBranch, branches, addLink) {
  */
 function executeQuery(url, callback) {
   var request = new XMLHttpRequest();
-  request.open("POST", "https://api.crom.avn.sh/graphql", true);
-  request.setRequestHeader("Content-Type", "application/json");
+  var requestUrl =
+    "https://api.crom.avn.sh/graphql?query=" +
+    encodeURIComponent(query) +
+    "&variables=" +
+    encodeURIComponent(JSON.stringify({ url: url }));
+  request.open("GET", requestUrl, true);
+  request.setRequestHeader("Accept", "application/json");
   request.addEventListener("readystatechange", function () {
     if (request.readyState === XMLHttpRequest.DONE) {
       try {
@@ -157,5 +162,5 @@ function executeQuery(url, callback) {
       }
     }
   });
-  request.send(JSON.stringify({ query: query, variables: { url: url } }));
+  request.send();
 }


### PR DESCRIPTION
Currently, making POST requests [with a JSON content type](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header) means that the browser needs to make a [preflight request](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) first, and that adds an additional request overhead. The preflight request itself doesn't add much load to the API server, and it probably doesn't add a _huge_ overhead to the client either, but with the server running out of a single geographic region, switching to a "CORS-safe" GET request would spare a good chunk of a second of latency for the end-user, depending on their location. In the long term, this would also open up the avenue for basic HTTP-layer caching.

Implementation-wise, GraphQL doesn't exactly have an official spec for interfacing with HTTP, but the Crom API's custom implementation follows [the guidelines](https://graphql.org/learn/serving-over-http), which includes a recommendation for making requests over GET. The accept header is there so that the browser doesn't serve the playground HTML instead (which it would if the accept included text/html or \*/\*). Couldn't use URLSearchParams with the ES5 limitation, but the alternative isn't so bad. Also, I drafted this in the GitHub editor, so I haven't actually tested this change.