### PR TITLE
Add scpfoundation.net support through Crom

### DIFF
--- a/js/branches-info-scp.js
+++ b/js/branches-info-scp.js
@@ -79,8 +79,8 @@ export var scpBranches = {
   ru: {
     name: "Русский",
     head: "На других языках",
-    url: "http://scp-ru.wikidot.com/",
-    id: "169125",
+    url: "https://scpfoundation.net/",
+    id: "",
     category: "",
   },
   es: {

--- a/js/lookup/crom.js
+++ b/js/lookup/crom.js
@@ -69,8 +69,8 @@ export function cromLookup(currentBranch, branches, fullname, addLink) {
  * @param {String} url
  */
 function normaliseUrl(url) {
-  if (url.indexOf(".wikidot.com") === -1) {
-    throw new Error("Crom requires wikidot.com branch URLs (" + url + ")");
+  if (url.indexOf(".wikidot.com") === -1 && url.indexOf("scpfoundation.net") === -1) {
+    throw new Error("Crom requires wikidot.com or scpfoundation.net branch URLs (" + url + ")");
   }
   return url.replace(/^https:/, "http:");
 }


### PR DESCRIPTION
What it says on the tin. The Crom API has minimal support for returning scpfoundation.net translation URLs (but without `wikidotInfo` for obvious reasons). Still, is good enough for the interwiki. The scheme is still `http://` for the API.