### PR TITLE
Fix missing accent in 'Český'

### DIFF
--- a/js/branches-info-scp.js
+++ b/js/branches-info-scp.js
@@ -7,7 +7,7 @@ export var scpBranches = {
     category: "",
   },
   cs: {
-    name: "Česky",
+    name: "Český",
     head: "V jiných jazycích",
     url: "https://scp-cs.wikidot.com/",
     id: "2060442",


### PR DESCRIPTION
See e.g. https://en.wiktionary.org/wiki/%C4%8Desk%C3%BD and xref https://discord.com/channels/877710488673329162/877753263271858187/1398258745766580327