### PR TITLE
Add documentation to published resizeIframe

### DIFF
--- a/build.js
+++ b/build.js
@@ -16,15 +16,7 @@ esbuild.buildSync({
   target: dev ? "esnext" : "es5",
 });
 
-esbuild.buildSync({
-  entryPoints: ["js/resizeIframe.js"],
-  outdir: "dist",
-  bundle: true,
-  minify: !dev,
-  sourcemap: dev ? "inline" : true,
-  target: dev ? "esnext" : "es5",
-  globalName: "resizeIframe",
-});
+fs.copyFileSync("js/resizeIframe.js", "dist/resizeIframe.js");
 
 ["interwikiFrame", "styleFrame", "index"].forEach(function (frame) {
   fs.copyFileSync("html/" + frame + ".html", "dist/" + frame + ".html");

--- a/js/interwiki.js
+++ b/js/interwiki.js
@@ -6,7 +6,9 @@ import { scpBranches } from "./branches-info-scp";
 import { wlBranches } from "./branches-info-wl";
 
 /**
- * @type {import("./resizeIframe").createResizeIframe}
+ * Provided globally by resizeIframe.js
+ *
+ * @type {(site: String, frameId: String, debounceTime?: Number) => ((height?: Number) => void)}
  */
 var createResizeIframe = window.resizeIframe.createResizeIframe;
 

--- a/js/resizeIframe.js
+++ b/js/resizeIframe.js
@@ -47,7 +47,7 @@
  * @param {Number=} [debounceTime] - Debounce delay to stagger repeated calls to the resizer. Defaults to 750 ms.
  * @returns {((height: Number=) => void)} Debounced function that resizes the iframe. Optional height parameter sets the height of the iframe in pixels; if not set, the height is calculated from the document. Float and string values are OK (e.g. 10.5 and "10.5").
  */
-export function createResizeIframe(site, frameId, debounceTime) {
+function createResizeIframe(site, frameId, debounceTime) {
   if (debounceTime == null) debounceTime = 750;
 
   var container = document.getElementById("resizer-container");
@@ -97,7 +97,7 @@ export function createResizeIframe(site, frameId, debounceTime) {
  * @param {Number} wait - The number of milliseconds to wait after any call to the debounced function before executing it.
  * @returns {Function} The debounced function.
  */
-export function debounce(func, wait) {
+function debounce(func, wait) {
   var timeout = 0;
   return function () {
     var context = this;
@@ -108,3 +108,8 @@ export function debounce(func, wait) {
     }, wait);
   };
 }
+
+window.resizeIframe = {
+  createResizeIframe: createResizeIframe,
+  debounce: debounce,
+};

--- a/js/resizeIframe.js
+++ b/js/resizeIframe.js
@@ -1,10 +1,51 @@
 /**
+ * This script is used to resize iframes to match their contents. It is intended for use in the interwiki iframe to accommodate different numbers of translations per page, but it can be used to resize any iframe on wikidot.
+ *
+ * How to use:
+ *
+ * 1. Import this script in the <head> of the page to be used as an iframe:
+ *
+ *    <script src="https://interwiki.scpwiki.com/resizeIframe.js" defer></script>
+ *
+ * 2. Define a dummy resize function to be used before the script loads:
+ *
+ *    window.resize = () => {};
+ *
+ * 3. After load, replace the dummy function with the actual resizer function:
+ *
+ *    addEventListener("load", () => {
+ *      window.resize = window.resizeIframe.createResizeIframe(
+ *        document.referrer,
+ *        location.href.replace(/^.*\//, "/"),
+ *        100,
+ *      );
+ *    });
+ *
+ * 4. Whenever you want to resize the iframe, call the function:
+ *
+ *    window.resize(); // Auto-resize to match the document height
+ *    window.resize(500); // Resize to 500px
+ *
+ * 5. If your iframe is defined in a [[html]] block, it already has Wikidot's auto-resizing script.
+ *    Disable it if you need to use this script to control the resizing:
+ *
+ *   document.querySelectorAll(
+ *     "script[src*='common--javascript/html-block-iframe.js']"
+ *   ).forEach(s => s.remove())
+ *   addEventListener("load", () => {
+ *     document.querySelectorAll(
+ *       "iframe[src*='common--javascript/resize-iframe.html']"
+ *     ).forEach(i => i.remove())
+ *   });
+ */
+
+/**
  * Constructs and returns a function that, when called, resizes the current iframes to match its contents or the given height. The function is debounced.
  *
  * @param {String} site - The base URL of the site.
  * @param {String} frameId - The last segment of the URL of the interwiki iframe, used by Wikidot to identify it when resizing it.
  * @param {Number=} [debounceTime] - Debounce delay to stagger repeated calls to the resizer. Defaults to 750 ms.
- * @returns {((height: Number=) => void)} Debounced function that resizes the iframe. Optional height parameter sets the height of the iframe; if not set, the height is calculated from the document.
+ * @returns {((height: Number=) => void)} Debounced function that resizes the iframe. Optional height parameter sets the height of the iframe in pixels; if not set, the height is calculated from the document. Float and string values are OK (e.g. 10.5 and "10.5").
  */
 export function createResizeIframe(site, frameId, debounceTime) {
   if (debounceTime == null) debounceTime = 750;


### PR DESCRIPTION
https://interwiki.scpwiki.com/resizeIframe.js is currently:

```
var resizeIframe=(function(){var u=Object.defineProperty;var m=Object.getOwnPropertyDescriptor;var f=Object.getOwnPropertyNames;var p=Object.prototype.hasOwnProperty;var d=function(n,e){for(var t in e)u(n,t,{get:e[t],enumerable:!0})},v=function(n,e,t,r){if(e&&typeof e=="object"||typeof e=="function")for(var i=f(e),c=0,o=i.length,a;c<o;c++)a=i[c],!p.call(n,a)&&a!==t&&u(n,a,{get:function(s){return e[s]}.bind(null,a),enumerable:!(r=m(e,a))||r.enumerable});return n};var z=function(n){return v(u({},"__esModule",{value:!0}),n)};var x={};d(x,{createResizeIframe:function(){return y},debounce:function(){return l}});function y(n,e,t){t==null&&(t=750);var r=document.getElementById("resizer-container");r==null&&(r=document.createElement("div"),r.id="resizer-container",document.body.appendChild(r));var i=document.createElement("iframe");i.style.display="none",r.appendChild(i),e=e.replace(/^\/+/,"");var c=function(o){o==null&&(o=r.getBoundingClientRect().top,o&&(o+=1));var a=n+"/common--javascript/resize-iframe.html?#"+o+"/"+e;i.src!==a&&(i.src="about:blank",setTimeout(function(){i.src=a},50))};return l(c,t)}function l(n,e){var t=0;return function(){var r=this,i=arguments;clearTimeout(t),t=setTimeout(function(){n.apply(r,i)},e)}}return z(x);})();
//# sourceMappingURL=resizeIframe.js.map
```

considering that this is the URL casual users in the wild will encounter, and be recommended to use by people like me, this is basically useless. a bit of documentation to explain what it does and how to use it, along with making the code readable, would go a long way

this PR's version: https://interwiki.scpwiki.com/pr-preview/pr-30/resizeIframe.js